### PR TITLE
Add coordinates info to url when coming from non-index car tiles

### DIFF
--- a/frontend/src/components/FavoritesPage/FavoriteIndexItem/index.js
+++ b/frontend/src/components/FavoritesPage/FavoriteIndexItem/index.js
@@ -7,6 +7,7 @@ import Spinner from "../../Spinner";
 const FavoriteIndexItem = ({ favorite }) => {
   const car = favorite.car;
   const history = useHistory();
+  const currentSearchParams = new URLSearchParams(window.location.search);
 
   const avgCarRating = () => {
     const avg =
@@ -27,11 +28,17 @@ const FavoriteIndexItem = ({ favorite }) => {
     return <Spinner />;
   }
 
+  const handleTileClick = () => {
+    currentSearchParams.delete("viewport");
+    currentSearchParams.set("zoom", 17);
+    history.push({
+      pathname: `/cars/${car.id}`,
+      search: currentSearchParams.toString(),
+    });
+  };
+
   return (
-    <div
-      id="fav-index-item-container"
-      onClick={() => history.push(`/cars/${car.id}`)}
-    >
+    <div id="fav-index-item-container" onClick={handleTileClick}>
       <div id="fav-image-container">
         {car.photosUrl && (
           <img
@@ -41,7 +48,7 @@ const FavoriteIndexItem = ({ favorite }) => {
           />
         )}
       </div>
-      <div id="fav-tile-info" onClick={() => history.push(`/cars/${car.id}`)}>
+      <div id="fav-tile-info" onClick={handleTileClick}>
         <h2 id="fav-name">{`${car.make} ${car.model} ${car.year}`}</h2>
         <div id="fav-tile-trips-and-host-info">
           <p id="fav-tile-rating-trips-container">
@@ -56,10 +63,7 @@ const FavoriteIndexItem = ({ favorite }) => {
         </div>
       </div>
       <div id="fav-price-container">
-        <div
-          id="fav-price-container"
-          onClick={() => history.push(`/cars/${car.id}`)}
-        >
+        <div id="fav-price-container" onClick={handleTileClick}>
           <h3>{`$${car.dailyRate} / day`}</h3>
         </div>
       </div>

--- a/frontend/src/components/ProfilePage/CarReviewTile/index.js
+++ b/frontend/src/components/ProfilePage/CarReviewTile/index.js
@@ -7,6 +7,7 @@ import { AiFillCar } from "react-icons/ai";
 const CarReviewTile = ({ review }) => {
   const history = useHistory();
   const sessionUser = useSelector((state) => state.session.user);
+  const currentSearchParams = new URLSearchParams(window.location.search);
 
   const dateFormat = (utcDateString) => {
     const options = { month: "long", day: "numeric", year: "numeric" };
@@ -43,13 +44,19 @@ const CarReviewTile = ({ review }) => {
     );
   };
 
+  const handleTileClick = () => {
+    currentSearchParams.delete("viewport");
+    currentSearchParams.set("zoom", 17);
+    history.push({
+      pathname: `/cars/${review.car.id}`,
+      search: currentSearchParams.toString(),
+    });
+  };
+
   return (
     <div id="review-index-item-container">
       <div>
-        <div
-          id="review-driver-image-container"
-          onClick={() => history.push(`/cars/${review.car.id}`)}
-        >
+        <div id="review-driver-image-container" onClick={handleTileClick}>
           {carPic()}
         </div>
       </div>

--- a/frontend/src/components/TripsPage/TripIndexItem/index.js
+++ b/frontend/src/components/TripsPage/TripIndexItem/index.js
@@ -3,6 +3,8 @@ import { useHistory } from "react-router-dom";
 
 const TripIndexItem = ({ trip, reviews }) => {
   const history = useHistory();
+  const currentSearchParams = new URLSearchParams(window.location.search);
+
   const dateFormat = (utcDateString) => {
     const options = { month: "long", day: "numeric" };
     const utcDate = new Date(utcDateString);
@@ -31,12 +33,18 @@ const TripIndexItem = ({ trip, reviews }) => {
     }
   };
 
+  const handleTileClick = () => {
+    currentSearchParams.delete("viewport");
+    currentSearchParams.set("zoom", 17);
+    history.push({
+      pathname: `/cars/${trip.car.id}`,
+      search: currentSearchParams.toString(),
+    });
+  };
+
   return (
     <div id="trips-item-container">
-      <div
-        id="trip-car-image-container"
-        onClick={() => history.push(`/cars/${trip.car.id}`)}
-      >
+      <div id="trip-car-image-container" onClick={handleTileClick}>
         <img
           src={trip.car.photosUrl[0]}
           alt="car image"


### PR DESCRIPTION
Fix bug where coming from non-search index car tiles the car show map didn't get a zoom level input. Now the zoom info is added to url params upon clicking those tiles, so car location on map renders correctly.