### PR TITLE
Futureproof geocode

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,9 +266,10 @@ const handlePlaceOnSelect = (address) => {
             }
             //set viewport from Google Place's API callback
             if (results[0].geometry.viewport) {
+              const viewportCoords = results[0].geometry.viewport.toJSON();
               existingSearchParams.set(
                 "viewport",
-                `${results[0].geometry.viewport.Ha.hi},${results[0].geometry.viewport.Ha.lo}, ${results[0].geometry.viewport.Va.hi}, ${results[0].geometry.viewport.Va.lo}`
+                `${viewportCoords.east},${viewportCoords.west}, ${viewportCoords.north}, ${viewportCoords.south}`
               );
             }
             existingSearchParams.set("location", address);

--- a/frontend/src/components/SearchBar/index.js
+++ b/frontend/src/components/SearchBar/index.js
@@ -37,10 +37,6 @@ const SearchBar = () => {
           "viewport",
           `${viewportCoords.east},${viewportCoords.west}, ${viewportCoords.north}, ${viewportCoords.south}`
         );
-        // searchParams.set(
-        //   "viewport",
-        //   `${results.geometry.viewport.Ha.hi},${results.geometry.viewport.Ha.lo}, ${results.geometry.viewport.Va.hi}, ${results.geometry.viewport.Va.lo}`
-        // );
       }
       searchParams.delete("zoom");
     } else {

--- a/frontend/src/components/SearchBar/index.js
+++ b/frontend/src/components/SearchBar/index.js
@@ -32,10 +32,15 @@ const SearchBar = () => {
       searchParams.set("coords", `${coords.lat},${coords.lng}`);
       searchParams.set("location", where);
       if (results) {
+        const viewportCoords = results.geometry.viewport.toJSON();
         searchParams.set(
           "viewport",
-          `${results.geometry.viewport.Ha.hi},${results.geometry.viewport.Ha.lo}, ${results.geometry.viewport.Va.hi}, ${results.geometry.viewport.Va.lo}`
+          `${viewportCoords.east},${viewportCoords.west}, ${viewportCoords.north}, ${viewportCoords.south}`
         );
+        // searchParams.set(
+        //   "viewport",
+        //   `${results.geometry.viewport.Ha.hi},${results.geometry.viewport.Ha.lo}, ${results.geometry.viewport.Va.hi}, ${results.geometry.viewport.Va.lo}`
+        // );
       }
       searchParams.delete("zoom");
     } else {

--- a/frontend/src/components/SearchLine/index.js
+++ b/frontend/src/components/SearchLine/index.js
@@ -120,9 +120,14 @@ const SearchLine = () => {
               existingSearchParams.set("dates", dateRange);
             }
             if (results[0].geometry.viewport) {
+              const viewportCoords = results[0].geometry.viewport.toJSON();
+              // existingSearchParams.set(
+              //   "viewport",
+              //   `${results[0].geometry.viewport.Ha.hi},${results[0].geometry.viewport.Ha.lo}, ${results[0].geometry.viewport.Va.hi}, ${results[0].geometry.viewport.Va.lo}`
+              // );
               existingSearchParams.set(
                 "viewport",
-                `${results[0].geometry.viewport.Ha.hi},${results[0].geometry.viewport.Ha.lo}, ${results[0].geometry.viewport.Va.hi}, ${results[0].geometry.viewport.Va.lo}`
+                `${viewportCoords.east},${viewportCoords.west}, ${viewportCoords.north}, ${viewportCoords.south}`
               );
             }
             existingSearchParams.set("location", address);

--- a/frontend/src/components/SearchLine/index.js
+++ b/frontend/src/components/SearchLine/index.js
@@ -121,10 +121,6 @@ const SearchLine = () => {
             }
             if (results[0].geometry.viewport) {
               const viewportCoords = results[0].geometry.viewport.toJSON();
-              // existingSearchParams.set(
-              //   "viewport",
-              //   `${results[0].geometry.viewport.Ha.hi},${results[0].geometry.viewport.Ha.lo}, ${results[0].geometry.viewport.Va.hi}, ${results[0].geometry.viewport.Va.lo}`
-              // );
               existingSearchParams.set(
                 "viewport",
                 `${viewportCoords.east},${viewportCoords.west}, ${viewportCoords.north}, ${viewportCoords.south}`


### PR DESCRIPTION
Prevent future changes in how google geocode tool returns viewport coordinates from breaking map. Coordinates are now extracted from the JSON response as 'south' 'east' 'west' 'north'.